### PR TITLE
Basic collision

### DIFF
--- a/src/graphical_core/input.rs
+++ b/src/graphical_core/input.rs
@@ -36,9 +36,13 @@ impl InputState {
         self.pressed_keys.contains(&key)
     }
 
-    pub fn update_camera(&mut self, camera: &mut Camera, delta_time: f32) {
+    pub fn update_camera(&mut self, camera: &mut Camera, delta_time: f32, fly_mode: bool) {
         self.apply_mouse_look(camera);
-        self.apply_movement(camera, delta_time);
+        if fly_mode {
+            self.apply_fly_movement(camera, delta_time);
+        } else {
+            self.apply_walk_movement(camera, delta_time);
+        }
     }
 
     fn apply_mouse_look(&mut self, camera: &mut Camera) {
@@ -46,11 +50,11 @@ impl InputState {
         self.mouse_delta = (0.0, 0.0);
 
         camera.yaw += dx as f32 * MOUSE_SENSITIVITY;
-        camera.pitch += dy as f32 * MOUSE_SENSITIVITY;
+        camera.pitch -= dy as f32 * MOUSE_SENSITIVITY;
         camera.pitch = camera.pitch.clamp(-MAX_PITCH, MAX_PITCH);
     }
 
-    fn apply_movement(&self, camera: &mut Camera, delta_time: f32) {
+    fn apply_fly_movement(&self, camera: &mut Camera, delta_time: f32) {
         let speed = MOVE_SPEED * delta_time;
         let front = camera.front();
         let right = camera.right();
@@ -72,6 +76,29 @@ impl InputState {
         }
         if self.is_pressed(KeyCode::KeyE) {
             camera.position += glam::Vec3::Y * speed;
+        }
+    }
+
+    /// Walk movement: WASD moves horizontally (ignoring pitch), no Q/E vertical.
+    fn apply_walk_movement(&self, camera: &mut Camera, delta_time: f32) {
+        let speed = MOVE_SPEED * delta_time;
+        let front = camera.front();
+        let right = camera.right();
+
+        // Flatten front vector to horizontal plane
+        let forward = glam::Vec3::new(front.x, 0.0, front.z).normalize_or_zero();
+
+        if self.is_pressed(KeyCode::KeyW) {
+            camera.position += forward * speed;
+        }
+        if self.is_pressed(KeyCode::KeyS) {
+            camera.position -= forward * speed;
+        }
+        if self.is_pressed(KeyCode::KeyD) {
+            camera.position += right * speed;
+        }
+        if self.is_pressed(KeyCode::KeyA) {
+            camera.position -= right * speed;
         }
     }
 }

--- a/src/graphical_core/vulkan_object.rs
+++ b/src/graphical_core/vulkan_object.rs
@@ -83,6 +83,13 @@ pub struct VulkanApplication {
     chunk_meshes: ChunkMeshMap,
     last_player_chunk: [i32; 2],
 }
+
+impl VulkanApplication {
+    pub fn world(&self) -> &World {
+        &self.world
+    }
+}
+
 impl VulkanApplication {
     /// Creates a fully initialized Vulkan renderer for the given window.
     ///

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,6 +6,7 @@ use graphical_core::camera::Camera;
 use graphical_core::input::InputState;
 use graphical_core::vulkan_object::VulkanApplication;
 use std::time::Instant;
+use voxel::player::Player;
 use vulkanalia::{prelude::v1_0::*, Version};
 use winit::{
     dpi::LogicalSize,
@@ -37,6 +38,7 @@ fn main() -> Result<()> {
     let mut minimized = false;
     let mut camera = Camera::default();
     let mut input = InputState::new();
+    let mut player = Player::new();
     let mut last_frame = Instant::now();
 
     event_handler
@@ -85,7 +87,11 @@ fn main() -> Result<()> {
                 let delta_time = (now - last_frame).as_secs_f32();
                 last_frame = now;
 
+                let old_position = camera.position;
                 input.update_camera(&mut camera, delta_time);
+                let world = application.world();
+                player.apply_physics(&mut camera.position, delta_time, world);
+                player.resolve_horizontal(&mut camera.position, old_position, world);
                 user_window.request_redraw();
             }
             Event::WindowEvent {

--- a/src/main.rs
+++ b/src/main.rs
@@ -70,6 +70,12 @@ fn main() -> Result<()> {
                             if key_code == KeyCode::Escape {
                                 exit_program(&mut destroy_application, current_window, &mut application);
                             }
+                            if key_code == KeyCode::KeyF && !key_event.repeat {
+                                player.toggle_fly_mode();
+                            }
+                            if key_code == KeyCode::Space {
+                                player.jump();
+                            }
                             input.key_pressed(key_code);
                         }
                         ElementState::Released => input.key_released(key_code),
@@ -88,10 +94,10 @@ fn main() -> Result<()> {
                 last_frame = now;
 
                 let old_position = camera.position;
-                input.update_camera(&mut camera, delta_time);
+                input.update_camera(&mut camera, delta_time, player.fly_mode);
                 let world = application.world();
-                player.apply_physics(&mut camera.position, delta_time, world);
                 player.resolve_horizontal(&mut camera.position, old_position, world);
+                player.apply_physics(&mut camera.position, delta_time, world);
                 user_window.request_redraw();
             }
             Event::WindowEvent {

--- a/src/voxel/mod.rs
+++ b/src/voxel/mod.rs
@@ -1,5 +1,6 @@
 pub mod block;
 pub mod chunk;
 pub mod meshing;
+pub mod player;
 pub mod terrain;
 pub mod world;

--- a/src/voxel/player.rs
+++ b/src/voxel/player.rs
@@ -1,0 +1,96 @@
+use super::world::World;
+use glam::Vec3;
+
+const GRAVITY: f32 = 20.0;
+const PLAYER_HEIGHT: f32 = 1.7;
+const PLAYER_HALF_WIDTH: f32 = 0.3;
+
+pub struct Player {
+    pub velocity: Vec3,
+    pub on_ground: bool,
+    pub fly_mode: bool,
+}
+
+impl Player {
+    pub fn new() -> Self {
+        Self {
+            velocity: Vec3::ZERO,
+            on_ground: false,
+            fly_mode: true,
+        }
+    }
+
+    /// Applies gravity and resolves vertical collision against the world.
+    pub fn apply_physics(&mut self, position: &mut Vec3, delta_time: f32, world: &World) {
+        if self.fly_mode {
+            return;
+        }
+
+        // Apply gravity to vertical velocity
+        self.velocity.y -= GRAVITY * delta_time;
+
+        // Move vertically
+        position.y += self.velocity.y * delta_time;
+
+        // Check ground collision (feet position)
+        let feet_y = position.y - PLAYER_HEIGHT;
+        if is_colliding(position.x, feet_y, position.z, world) {
+            // Snap to top of block
+            let block_top = feet_y.floor() + 1.0;
+            position.y = block_top + PLAYER_HEIGHT;
+            self.velocity.y = 0.0;
+            self.on_ground = true;
+        } else {
+            self.on_ground = false;
+        }
+
+        // Check head collision (ceiling)
+        if is_colliding(position.x, position.y, position.z, world) {
+            position.y = position.y.floor();
+            self.velocity.y = self.velocity.y.min(0.0);
+        }
+    }
+
+    /// Resolves horizontal collision by checking each axis independently.
+    pub fn resolve_horizontal(&self, position: &mut Vec3, old_position: Vec3, world: &World) {
+        if self.fly_mode {
+            return;
+        }
+
+        let feet_y = position.y - PLAYER_HEIGHT;
+        let head_y = position.y;
+        let check_heights = [feet_y, feet_y + 0.5, head_y - 0.5, head_y];
+
+        // Check X axis
+        let test_x = position.x + PLAYER_HALF_WIDTH * position.x.partial_cmp(&old_position.x).map_or(0.0, sign);
+        for &y in &check_heights {
+            if world.is_solid(test_x, y, position.z) {
+                position.x = old_position.x;
+                break;
+            }
+        }
+
+        // Check Z axis
+        let test_z = position.z + PLAYER_HALF_WIDTH * position.z.partial_cmp(&old_position.z).map_or(0.0, sign);
+        for &y in &check_heights {
+            if world.is_solid(position.x, y, test_z) {
+                position.z = old_position.z;
+                break;
+            }
+        }
+    }
+}
+
+fn sign(ord: std::cmp::Ordering) -> f32 {
+    match ord {
+        std::cmp::Ordering::Greater => 1.0,
+        std::cmp::Ordering::Less => -1.0,
+        std::cmp::Ordering::Equal => 0.0,
+    }
+}
+
+fn is_colliding(x: f32, y: f32, z: f32, world: &World) -> bool {
+    // Check the 4 corners of the player's horizontal footprint
+    let hw = PLAYER_HALF_WIDTH;
+    world.is_solid(x - hw, y, z - hw) || world.is_solid(x + hw, y, z - hw) || world.is_solid(x - hw, y, z + hw) || world.is_solid(x + hw, y, z + hw)
+}

--- a/src/voxel/player.rs
+++ b/src/voxel/player.rs
@@ -2,6 +2,7 @@ use super::world::World;
 use glam::Vec3;
 
 const GRAVITY: f32 = 20.0;
+const JUMP_VELOCITY: f32 = 8.0;
 const PLAYER_HEIGHT: f32 = 1.7;
 const PLAYER_HALF_WIDTH: f32 = 0.3;
 
@@ -18,6 +19,18 @@ impl Player {
             on_ground: false,
             fly_mode: true,
         }
+    }
+
+    pub fn jump(&mut self) {
+        if self.on_ground && !self.fly_mode {
+            self.velocity.y = JUMP_VELOCITY;
+            self.on_ground = false;
+        }
+    }
+
+    pub fn toggle_fly_mode(&mut self) {
+        self.fly_mode = !self.fly_mode;
+        self.velocity = Vec3::ZERO;
     }
 
     /// Applies gravity and resolves vertical collision against the world.

--- a/src/voxel/world.rs
+++ b/src/voxel/world.rs
@@ -1,4 +1,5 @@
-use super::chunk::Chunk;
+use super::block::BlockType;
+use super::chunk::{Chunk, CHUNK_SIZE};
 use super::terrain;
 use std::collections::HashMap;
 
@@ -50,6 +51,25 @@ impl World {
         WorldDelta { loaded, unloaded }
     }
 
+    /// Returns the block at a world-space position, or Air if the chunk isn't loaded.
+    pub fn get_block(&self, wx: f32, wy: f32, wz: f32) -> BlockType {
+        // Out-of-bounds vertically is always air
+        if wy < 0.0 || wy >= CHUNK_SIZE as f32 {
+            return BlockType::Air;
+        }
+
+        let (cx, cz, lx, ly, lz) = world_to_chunk(wx, wy, wz);
+        match self.chunks.get(&[cx, cz]) {
+            Some(chunk) => chunk.get(lx, ly, lz),
+            None => BlockType::Air,
+        }
+    }
+
+    /// Returns true if the block at a world-space position is solid.
+    pub fn is_solid(&self, wx: f32, wy: f32, wz: f32) -> bool {
+        self.get_block(wx, wy, wz).is_opaque()
+    }
+
     pub fn get_chunk(&self, cx: i32, cz: i32) -> Option<&Chunk> {
         self.chunks.get(&[cx, cz])
     }
@@ -57,6 +77,17 @@ impl World {
     pub fn chunk_positions(&self) -> impl Iterator<Item = [i32; 2]> + '_ {
         self.chunks.keys().copied()
     }
+}
+
+/// Converts world-space float coordinates to (chunk_x, chunk_z, local_x, local_y, local_z).
+fn world_to_chunk(wx: f32, wy: f32, wz: f32) -> (i32, i32, usize, usize, usize) {
+    let size = CHUNK_SIZE as f32;
+    let cx = wx.div_euclid(size) as i32;
+    let cz = wz.div_euclid(size) as i32;
+    let lx = wx.rem_euclid(size) as usize;
+    let ly = wy as usize;
+    let lz = wz.rem_euclid(size) as usize;
+    (cx, cz, lx, ly, lz)
 }
 
 fn in_range(cx: i32, cz: i32, player_cx: i32, player_cz: i32, radius: i32) -> bool {


### PR DESCRIPTION
## Description
Adds ground-based player movement with physics and collision detection.

- World block query converting world-space positions to chunk + local coordinates (div_euclid for correct negative coordinate handling)
- AABB collision against solid blocks with separate vertical/horizontal resolution
- Gravity with ground snapping and jump mechanic (Space)
- Fly/walk mode toggle (F) — fly mode is no-clip for debugging, walk mode has full collision
- Horizontal-only movement in walk mode (flattened forward vector)
- Fix inverted mouse Y-axis


## Type of Change
- [X] Bug fix
- [X] New feature
- [ ] Breaking change
- [ ] Documentation update

## Checklist
- [X] I ran `cargo fmt --all` (code is formatted)
- [X] I ran `cargo clippy --workspace --all-targets -- -D warnings` (no warnings)
- [X] I ran `cargo test --workspace` (all tests pass)
- [ ] I added tests for new functionality
- [ ] I updated relevant documentation