### PR TITLE
fix: macOS compatibility for MoltenVK

### DIFF
--- a/src/graphical_core/camera.rs
+++ b/src/graphical_core/camera.rs
@@ -61,7 +61,10 @@ pub struct UniformBufferObject {
 pub fn create_uniform_buffer(device: &Device, instance: &Instance, vulkan_application_data: &mut VulkanApplicationData) -> anyhow::Result<()> {
     let buffer_size_in_bytes = std::mem::size_of::<UniformBufferObject>() as u64;
     let buffer_usage_flags = vk::BufferUsageFlags::UNIFORM_BUFFER;
-    let properties = vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT | vk::MemoryPropertyFlags::DEVICE_LOCAL;
+    let mut properties = vk::MemoryPropertyFlags::HOST_VISIBLE | vk::MemoryPropertyFlags::HOST_COHERENT;
+    if !cfg!(target_os = "macos") {
+        properties |= vk::MemoryPropertyFlags::DEVICE_LOCAL;
+    }
 
     let (uniform_buffer, uniform_memory, uniform_ptr) = unsafe {
         allocate_buffer::<UniformBufferObject>(

--- a/src/graphical_core/commands.rs
+++ b/src/graphical_core/commands.rs
@@ -1,7 +1,9 @@
 use crate::graphical_core::compute_cull::{ComputeCullResources, CullPushConstants, DepthPyramidResources, DepthReducePush};
-use crate::graphical_core::vulkan_object::{DrawIndexedIndirectCommand, VulkanApplicationData};
+use crate::graphical_core::vulkan_object::{DrawIndexedIndirectCommand, VulkanApplicationData, MAX_INDIRECT_DRAWS};
 use crate::graphical_core::{self, MAX_FRAMES_IN_FLIGHT};
-use vulkanalia::vk::{DeviceV1_0, DeviceV1_2, Handle, HasBuilder};
+#[cfg(not(target_os = "macos"))]
+use vulkanalia::vk::DeviceV1_2;
+use vulkanalia::vk::{DeviceV1_0, Handle, HasBuilder};
 use vulkanalia::{vk, Device, Instance};
 
 /// Creates a framebuffer for each swapchain image view, attaching color and depth.
@@ -74,8 +76,12 @@ pub unsafe fn record_command_buffer(
         transition_pyramid_undefined_to_general(device, cmd, data);
     }
 
-    // Reset both draw counts to 0
+    // Reset draw counts (and on macOS, the indirect buffer) to 0
     device.cmd_fill_buffer(cmd, compute.draw_count_buffer, 0, 8, 0);
+    if cfg!(target_os = "macos") {
+        let indirect_size = (MAX_INDIRECT_DRAWS * std::mem::size_of::<DrawIndexedIndirectCommand>()) as u64;
+        device.cmd_fill_buffer(cmd, data.indirect_buffer, 0, indirect_size, 0);
+    }
     let fill_barrier = vk::MemoryBarrier::builder()
         .src_access_mask(vk::AccessFlags::TRANSFER_WRITE)
         .dst_access_mask(vk::AccessFlags::SHADER_READ | vk::AccessFlags::SHADER_WRITE);
@@ -115,7 +121,7 @@ pub unsafe fn record_command_buffer(
     // Draw phase 1 (begins render pass with clear)
     begin_render_pass(device, cmd, data, image_index);
     bind_graphics_state(device, cmd, data, vertex_buffer, index_buffer);
-    device.cmd_draw_indexed_indirect_count(cmd, data.indirect_buffer, 0, compute.draw_count_buffer, 0, PHASE2_DRAW_OFFSET, stride);
+    draw_indirect(device, cmd, data.indirect_buffer, 0, compute.draw_count_buffer, 0, PHASE2_DRAW_OFFSET, stride);
     device.cmd_end_render_pass(cmd);
 
     // === Build depth pyramid from phase 1 depth ===
@@ -144,15 +150,7 @@ pub unsafe fn record_command_buffer(
     // Draw phase 2 (resume render pass WITHOUT clearing — append to existing depth+color)
     begin_render_pass_no_clear(device, cmd, data, image_index);
     bind_graphics_state(device, cmd, data, vertex_buffer, index_buffer);
-    device.cmd_draw_indexed_indirect_count(
-        cmd,
-        data.indirect_buffer,
-        phase2_byte_offset,
-        compute.draw_count_buffer,
-        4,
-        PHASE2_DRAW_OFFSET,
-        stride,
-    );
+    draw_indirect(device, cmd, data.indirect_buffer, phase2_byte_offset, compute.draw_count_buffer, 4, PHASE2_DRAW_OFFSET, stride);
     device.cmd_end_render_pass(cmd);
 
     device.end_command_buffer(cmd)?;
@@ -204,6 +202,30 @@ unsafe fn compute_to_draw_barrier(device: &Device, cmd: vk::CommandBuffer) {
         &[] as &[vk::BufferMemoryBarrier],
         &[] as &[vk::ImageMemoryBarrier],
     );
+}
+
+/// On platforms with `draw_indirect_count`, uses the GPU-written count buffer.
+/// On macOS (MoltenVK), falls back to `cmd_draw_indexed_indirect` with a fixed max
+/// draw count — the indirect buffer is zeroed each frame so unused slots are no-ops.
+unsafe fn draw_indirect(
+    device: &Device,
+    cmd: vk::CommandBuffer,
+    buffer: vk::Buffer,
+    offset: u64,
+    _count_buffer: vk::Buffer,
+    _count_offset: u64,
+    max_draws: u32,
+    stride: u32,
+) {
+    #[cfg(target_os = "macos")]
+    {
+        let _ = (_count_buffer, _count_offset);
+        device.cmd_draw_indexed_indirect(cmd, buffer, offset, max_draws, stride);
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        device.cmd_draw_indexed_indirect_count(cmd, buffer, offset, _count_buffer, _count_offset, max_draws, stride);
+    }
 }
 
 unsafe fn begin_render_pass(device: &Device, cmd: vk::CommandBuffer, data: &VulkanApplicationData, framebuffer_index: usize) {

--- a/src/graphical_core/commands.rs
+++ b/src/graphical_core/commands.rs
@@ -121,7 +121,16 @@ pub unsafe fn record_command_buffer(
     // Draw phase 1 (begins render pass with clear)
     begin_render_pass(device, cmd, data, image_index);
     bind_graphics_state(device, cmd, data, vertex_buffer, index_buffer);
-    draw_indirect(device, cmd, data.indirect_buffer, 0, compute.draw_count_buffer, 0, PHASE2_DRAW_OFFSET, stride);
+    draw_indirect(
+        device,
+        cmd,
+        data.indirect_buffer,
+        0,
+        compute.draw_count_buffer,
+        0,
+        PHASE2_DRAW_OFFSET,
+        stride,
+    );
     device.cmd_end_render_pass(cmd);
 
     // === Build depth pyramid from phase 1 depth ===
@@ -150,7 +159,16 @@ pub unsafe fn record_command_buffer(
     // Draw phase 2 (resume render pass WITHOUT clearing — append to existing depth+color)
     begin_render_pass_no_clear(device, cmd, data, image_index);
     bind_graphics_state(device, cmd, data, vertex_buffer, index_buffer);
-    draw_indirect(device, cmd, data.indirect_buffer, phase2_byte_offset, compute.draw_count_buffer, 4, PHASE2_DRAW_OFFSET, stride);
+    draw_indirect(
+        device,
+        cmd,
+        data.indirect_buffer,
+        phase2_byte_offset,
+        compute.draw_count_buffer,
+        4,
+        PHASE2_DRAW_OFFSET,
+        stride,
+    );
     device.cmd_end_render_pass(cmd);
 
     device.end_command_buffer(cmd)?;

--- a/src/graphical_core/instance.rs
+++ b/src/graphical_core/instance.rs
@@ -60,7 +60,11 @@ pub unsafe fn create_instance(window: &Window, entry: &Entry, data: &mut VulkanA
 
     let mut debug_info = vk::DebugUtilsMessengerCreateInfoEXT::builder()
         .message_severity(vk::DebugUtilsMessageSeverityFlagsEXT::all())
-        .message_type(vk::DebugUtilsMessageTypeFlagsEXT::all())
+        .message_type(
+            vk::DebugUtilsMessageTypeFlagsEXT::GENERAL
+                | vk::DebugUtilsMessageTypeFlagsEXT::VALIDATION
+                | vk::DebugUtilsMessageTypeFlagsEXT::PERFORMANCE,
+        )
         .user_callback(Some(debug_callback));
 
     if VALIDATION_ENABLED {
@@ -100,7 +104,10 @@ pub unsafe fn create_logical_device(entry: &Entry, instance: &Instance, data: &m
         extensions.push(vk::KHR_PORTABILITY_SUBSET_EXTENSION.name.as_ptr());
     }
     let features = vk::PhysicalDeviceFeatures::builder().multi_draw_indirect(true);
-    let mut features_1_2 = vk::PhysicalDeviceVulkan12Features::builder().draw_indirect_count(true);
+    let mut features_1_2 = vk::PhysicalDeviceVulkan12Features::builder();
+    if !cfg!(target_os = "macos") {
+        features_1_2 = features_1_2.draw_indirect_count(true);
+    }
     let info = vk::DeviceCreateInfo::builder()
         .queue_create_infos(&queue_infos)
         .enabled_layer_names(&layers)

--- a/src/graphical_core/vulkan_object.rs
+++ b/src/graphical_core/vulkan_object.rs
@@ -243,7 +243,7 @@ unsafe fn create_transform_and_indirect_buffers(device: &Device, instance: &Inst
     let indirect_size = (MAX_INDIRECT_DRAWS * std::mem::size_of::<DrawIndexedIndirectCommand>()) as u64;
     let (ib, im, ip) = allocate_buffer::<DrawIndexedIndirectCommand>(
         indirect_size,
-        vk::BufferUsageFlags::INDIRECT_BUFFER | vk::BufferUsageFlags::STORAGE_BUFFER,
+        vk::BufferUsageFlags::INDIRECT_BUFFER | vk::BufferUsageFlags::STORAGE_BUFFER | vk::BufferUsageFlags::TRANSFER_DST,
         device,
         instance,
         data,


### PR DESCRIPTION
## Description
Fix Vulkan device creation and rendering on macOS by working around MoltenVK limitations.

- Use explicit debug messenger message type flags instead of `::all()` (avoids requiring `VK_EXT_device_address_binding_report`)
- Skip `draw_indirect_count` device feature on macOS (unsupported by MoltenVK)
- Fall back to `cmd_draw_indexed_indirect` on macOS with per-frame indirect buffer zeroing
- Add `TRANSFER_DST` usage flag to indirect buffer for `cmd_fill_buffer`
- Drop `DEVICE_LOCAL` from UBO memory flags on macOS (not exposed alongside `HOST_VISIBLE` by MoltenVK)

## Related Issues

## Type of Change
- [x] Bug fix

## Checklist
- [X] I ran `cargo fmt --all` (code is formatted)
- [X] I ran `cargo clippy --workspace --all-targets -- -D warnings` (no warnings)
- [X] I ran `cargo test --workspace` (all tests pass)
- [ ] I added tests for new functionality
- [ ] I updated relevant documentation